### PR TITLE
Extend CFLAGS in Makefiles instead of overriding them.

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -15,10 +15,11 @@
 # 
 -include ../def.mk 
  
-CC      = gcc
-#CFLAGS  = ${RSL_CFLAG} -fPIC -x c -DFPRINTFON
-CFLAGS  = ${RSL_CFLAG} -fPIC -g -x c
-LDFLAGS = -shared -Wall
+# use gcc if not set already
+CC      ?= gcc
+#CFLAGS  += ${RSL_CFLAG} -fPIC -x c -DFPRINTFON
+CFLAGS  += ${RSL_CFLAG} -fPIC -g -x c
+LDFLAGS += -shared -Wall
 
 # define where the vol2bird stuff is
 SRC_VOL2BIRD_DIR = .

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,10 +15,10 @@
 # 
 -include ../def.mk 
  
-CC      = gcc
-#CFLAGS  = -fPIC -x c -DFPRINTFON
-CFLAGS  = -I../lib -Wall -g
-LDFLAGS = -L../lib
+CC      ?= gcc
+#CFLAGS  += -fPIC -x c -DFPRINTFON
+CFLAGS  += -I../lib -Wall -g
+LDFLAGS += -L../lib
 
 # define where the vol2bird stuff is
 #SRC_VOL2BIRD_DIR         = /projects/baltrad/vol2bird/lib


### PR DESCRIPTION
On the Baltrad system, which uses GCC 4.x, the default C dialect is something more conservative than C99. Using `CFLAGS='-std=c99' ./configure ...` does not work because the Makefiles override `CFLAGS` instead of extending them.

This patch replaces uses of `CFLAGS = ...` with `CFLAGS += ...`, which fixes the problem.