### PR TITLE
add options.conf specification at command line (#186)

### DIFF
--- a/lib/constants.h
+++ b/lib/constants.h
@@ -128,9 +128,9 @@
 // Name of the program, to be stored as task attribute in ODIM
 #define PROGRAM "vol2bird"
 // Version of the program, to be stored as task_version attribute in ODIM
-#define VERSION "0.5.0.9185"
+#define VERSION "0.5.0.9186"
 // Date of latest version of the program
-#define VERSIONDATE "07-Feb-2022"
+#define VERSIONDATE "15-Feb-2022"
 
 
 //-------------------------------------------------------//

--- a/lib/constants.h
+++ b/lib/constants.h
@@ -128,7 +128,7 @@
 // Name of the program, to be stored as task attribute in ODIM
 #define PROGRAM "vol2bird"
 // Version of the program, to be stored as task_version attribute in ODIM
-#define VERSION "0.5.0.9186"
+#define VERSION "0.5.0.9187"
 // Date of latest version of the program
 #define VERSIONDATE "15-Feb-2022"
 

--- a/lib/libvol2bird.c
+++ b/lib/libvol2bird.c
@@ -4561,13 +4561,20 @@ done:
 
 
 // loads configuration data in the alldata struct
-int vol2birdLoadConfig(vol2bird_t* alldata) {
+int vol2birdLoadConfig(vol2bird_t* alldata, const char* optionsFile) {
 
     alldata->misc.loadConfigSuccessful = FALSE;
 
+    // load options.conf path from environment variable
     const char * optsConfFilename = getenv(OPTIONS_CONF);
+    
     if (optsConfFilename == NULL) {
-        optsConfFilename = OPTIONS_FILE;
+        if(optionsFile == NULL){
+            optsConfFilename = OPTIONS_FILE;
+        }
+        else{
+            optsConfFilename = optionsFile;
+        }
     }
     else{
         fprintf(stderr, "Searching user configuration file '%s' specified in environmental variable '%s'\n",optsConfFilename,OPTIONS_CONF);

--- a/lib/libvol2bird.h
+++ b/lib/libvol2bird.h
@@ -432,7 +432,7 @@ void vol2birdPrintPointsArray(vol2bird_t* alldata);
 
 void vol2birdPrintPointsArraySimple(vol2bird_t* alldata);
 
-int vol2birdLoadConfig(vol2bird_t* alldata);
+int vol2birdLoadConfig(vol2bird_t* alldata, const char* optionsFile);
 
 int vol2birdSetUp(PolarVolume_t* volume, vol2bird_t* alldata);
 


### PR DESCRIPTION
fix #186 by adding `-c` command line argument to specify an `options.conf`-style configuration file